### PR TITLE
Diagram tool links fix

### DIFF
--- a/Src/Eiffel/interface/new_graphical/case_tool/eiffel_studio/es_graph.e
+++ b/Src/Eiffel/interface/new_graphical/case_tool/eiffel_studio/es_graph.e
@@ -60,10 +60,10 @@ feature -- Access
 			-- Container of `Current'.
 			-- Used to access surface on which `Current' is displayed.
 
-	class_of_id (a_id: STRING): ES_CLASS
-			-- Class of `a_id'
+	class_of_name (a_name: STRING): ES_CLASS
+			-- Class of `a_name'
 		require
-			a_id_not_void: a_id /= Void
+			a_name_not_void: a_name /= Void
 		local
 			l_nodes: like nodes
 			l_class: ES_CLASS
@@ -75,7 +75,7 @@ feature -- Access
 				l_nodes.after or Result /= Void
 			loop
 				l_class ?= l_nodes.item
-				if l_class /= Void and then l_class.es_class_id.is_equal (a_id) then
+				if l_class /= Void and then l_class.name.is_equal (a_name) then
 					Result := l_class
 				end
 				l_nodes.forth
@@ -960,7 +960,7 @@ invariant
 	client_supplier_links_lookup_not_void: client_supplier_links_lookup /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2020, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2024, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/interface/new_graphical/case_tool/eiffel_view/eiffel_factory.e
+++ b/Src/Eiffel/interface/new_graphical/case_tool/eiffel_view/eiffel_factory.e
@@ -113,8 +113,8 @@ feature -- Access
 				if source_name /= Void then
 					target_name := node.attribute_by_name (target_string).value
 					if target_name /= Void then
-						source := l_world.model.class_of_id (source_name)
-						target := l_world.model.class_of_id (target_name)
+						source := l_world.model.class_of_name (source_name)
+						target := l_world.model.class_of_name (target_name)
 						if source /= Void and target /= Void then
 							if node_name.same_string (xml_client_supplier_figure_node_name) then
 								if source.has_supplier (target) then
@@ -207,7 +207,7 @@ feature {NONE} -- Constants
 		-- Xml string constants
 
 note
-	copyright:	"Copyright (c) 1984-2020, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2024, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[


### PR DESCRIPTION
Fixed: Inheritance and supplier links in the diagram tool get lost after retrieval from diagram XML files. Therefore they are not displayed and saved to diagram XML files anymore.