### PR TITLE
Bugfix/zad miner

### DIFF
--- a/Src/examples/vision2/zad_miner/ace/zad_miner.ecf
+++ b/Src/examples/vision2/zad_miner/ace/zad_miner.ecf
@@ -24,7 +24,6 @@
 			<concurrency support="none"/>
 		</capability>
 		<library name="base" location="$ISE_LIBRARY\library\base\base.ecf"/>
-		<library name="memory_analyzer" location="$ISE_LIBRARY\library\memory_analyzer\memory_analyzer.ecf"/>
 		<library name="time" location="$ISE_LIBRARY\library\time\time.ecf"/>
 		<library name="vision2" location="$ISE_LIBRARY\library\vision2\vision2.ecf"/>
 		<cluster name="root_cluster" location="..\src\"/>

--- a/Src/examples/vision2/zad_miner/src/miner_window.e
+++ b/Src/examples/vision2/zad_miner/src/miner_window.e
@@ -122,10 +122,6 @@ feature -- Initialization
 
 				--| prepare the battle field ... the field of mines
 			reset_mine_field
-
-			if attached (create {MA_WINDOW}.make ("c:\dev\trunk\src\library\memory_analyzer")) as w then
-				w.show
-			end
 		end;
 
 feature -- About box

--- a/Src/examples/vision2/zad_miner/src/miner_window.e
+++ b/Src/examples/vision2/zad_miner/src/miner_window.e
@@ -648,7 +648,7 @@ feature -- command action
 			is_debuggable := True
 		end
 
-	toggle_debug_action (z_key: EV_KEY)
+	toggle_debug_action
 			-- Toggle debugging action.
 		do
 			debugging := not debugging


### PR DESCRIPTION
Completely remove memory analyzer dependency
Memory analyzer dependency was introduced with commit https://github.com/ThomasGoering/EiffelStudio/commit/5c7da59023434b8c5e90525f63d638d825ca6568 (Converted old example to Void-safety.)

Debug feature fix